### PR TITLE
disable "/eval" chat command

### DIFF
--- a/main.js
+++ b/main.js
@@ -2230,7 +2230,8 @@ function doChatCommand(pc, msg, txt){
 	}else if (words[0] == '/eval'){
 
 		words.shift();
-		eval(words.join(" "));
+		//eval(words.join(" "));
+		pc.sendActivity('sorry, /eval is disabled');
 
 		// needed to make sure changes are propagated
 		pc.apiSendLocMsg({ type: 'location_event' });


### PR DESCRIPTION
Disabling the /eval chat command for the time being, for security
reasons. Can still be reenabled by uncommenting on an ad-hoc basis, if
really necessary.
