### PR TITLE
apiMoveOut is deprecated, use apiMoveOutX

### DIFF
--- a/players/player.js
+++ b/players/player.js
@@ -723,7 +723,7 @@ function teleportToLocation(tsid, x, y, args){
 				},
 				loading_info: target.getLoadingInfo(this)
 			});
-			this.location.apiMoveOutX(this, target);
+			this.location.apiMoveOutX(this, target, x, y);
 			return {
 				'ok' : 1,
 				'was_online' : 1


### PR DESCRIPTION
Fixes issues when teleporting requires a GS change.
