### PR TITLE
prevent inadvertently modifying skills DC

### DIFF
--- a/players/inc_skills.js
+++ b/players/inc_skills.js
@@ -401,7 +401,7 @@ function skills_get_all(is_admin){
 				ok = 0;
 			}
 			
-			out[i].queue = queue[i];
+			out[i].queue = utils.copy_hash(queue[i]);
 			out[i].queue.time_remaining = this.skills_points_to_seconds(queue[i].points_remaining, s.category_id);
 		}
 		


### PR DESCRIPTION
Fixes trello#32 https://trello.com/c/YERYigIi

While compiling the skill list, the skills_get_all function modifies
the skills DC object by adding 'time_remaining' to learning queue
elements (instead of just the return value object it is building). For
the skill currently being learned, this property ends up with the value
NaN, which causes an error in the persistence layer.
