### PR TITLE
avoid properties with value 'undefined'

### DIFF
--- a/items/ice_knob.js
+++ b/items/ice_knob.js
@@ -370,9 +370,18 @@ function startScraping(pc, msg){ // defined by ice_knob
 	pc['!scraping'] = this.tsid;
 	this.addScraper(pc);
 
-	var no_upgrade = pc.party_scraping;
-
-	var success = pc.runSkillPackage('ice_scraping', this, {word_progress: {type:"scrape2"}, tool_item: scraper, source_delta_y: 80, source_delta_x: 40, callback: 'onScrapingComplete', msg: msg, no_img_upgrades: no_upgrade});
+	var args = {
+		word_progress: {type: "scrape2"},
+		tool_item: scraper,
+		source_delta_y: 80,
+		source_delta_x: 40,
+		callback: 'onScrapingComplete',
+		msg: msg,
+	};
+	if (pc.hasOwnProperty('party_scraping')) {
+		args.no_img_upgrades = pc.party_scraping;
+	}
+	var success = pc.runSkillPackage('ice_scraping', this, args);
 
 	if (!success['ok']){
 		if (success['error_tool_broken']) {

--- a/items/mortar_barnacle.js
+++ b/items/mortar_barnacle.js
@@ -342,9 +342,18 @@ function startScraping(pc, msg){ // defined by mortar_barnacle
 
 	pc['!scraping'] = this.tsid;
 
-	var no_upgrade = pc.party_scraping;
-
-	var success = pc.runSkillPackage('scraping', this, {word_progress: config.word_progress_map['scrape'], tool_item: scraper, source_delta_y: 80, source_delta_x: 40, callback: 'onScrapingComplete', msg: msg, no_img_upgrades: no_upgrade});
+	var args = {
+		word_progress: config.word_progress_map['scrape'],
+		tool_item: scraper,
+		source_delta_y: 80,
+		source_delta_x: 40,
+		callback: 'onScrapingComplete',
+		msg: msg,
+	};
+	if (pc.hasOwnProperty('party_scraping')) {
+		args.no_img_upgrades = pc.party_scraping;
+	}
+	var success = pc.runSkillPackage('scraping', this, args);
 
 	if (!success['ok']){
 		delete pc['!scraping'];

--- a/items/test_item3.js
+++ b/items/test_item3.js
@@ -342,9 +342,18 @@ function startScraping(pc, msg){ // defined by mortar_barnacle
 
 	pc['!scraping'] = this.tsid;
 
-	var no_upgrade = pc.party_scraping;
-
-	var success = pc.runSkillPackage('scraping', this, {word_progress: config.word_progress_map['scrape'], tool_item: scraper, source_delta_y: 80, source_delta_x: 40, callback: 'onScrapingComplete', msg: msg, no_img_upgrades: no_upgrade});
+	var args = {
+		word_progress: config.word_progress_map['scrape'],
+		tool_item: scraper,
+		source_delta_y: 80,
+		source_delta_x: 40,
+		callback: 'onScrapingComplete',
+		msg: msg,
+	};
+	if (pc.hasOwnProperty('party_scraping')) {
+		args.no_img_upgrades = pc.party_scraping;
+	}
+	var success = pc.runSkillPackage('scraping', this, args);
 
 	if (!success['ok']){
 		delete pc['!scraping'];


### PR DESCRIPTION
Properties with a value of 'undefined' cannot be stored by the GS when
using the RethinkDB persistence back-end.