### PR TITLE
Change quoins for Rainbow Run to be currants to match video evidence

### DIFF
--- a/items/moving_quoin.js
+++ b/items/moving_quoin.js
@@ -488,7 +488,7 @@ function onPropsChanged(){ // defined by quoin
 			this.instanceProps.respawn_time = 15;
 			this.instanceProps.is_random = "0";
 			this.instanceProps.benefit = "1";
-			this.instanceProps.type = 'mood';
+			this.instanceProps.type = 'currants';
 			break;
 	//
 	// I edited these  favor ones down quite a bit on Oct 2, 2010

--- a/items/quoin.js
+++ b/items/quoin.js
@@ -449,7 +449,7 @@ function onPropsChanged(){ // defined by quoin
 			this.instanceProps.respawn_time = 15;
 			this.instanceProps.is_random = "0";
 			this.instanceProps.benefit = "1";
-			this.instanceProps.type = 'mood';
+			this.instanceProps.type = 'currants';
 			break;
 	//
 	// I edited these  favor ones down quite a bit on Oct 2, 2010


### PR DESCRIPTION
Quoins for Rainbow Run are defaulted to 'mood' which does not match
the video video evidence
(https://www.dropbox.com/sh/3t3iqmj7au52xmd/AAA8rFXUHrPVmEx2NiJaWcK-a
/Video/Rainbow%20Run?dl=0&preview=Rainbow+Run.mp4).
As these quoins respawn in under 25s, and are clearly currant quoins,
the simplest fix is to change the type setting.

Note that this fix cannot be tested because Rainbow Run does not yet
exist in fixtures.