### PR TITLE
Allow names in /who to be clicked.

### DIFF
--- a/groups/group.js
+++ b/groups/group.js
@@ -1106,7 +1106,9 @@ function chat_get_roster_msg(){
 	var names = [];
 	for (var i in this.chat_roster){
 		var pc = this.chat_roster[i];
-		if (pc !== null && pc !== undefined) names.push(utils.escape(pc.label));
+		if (pc !== null && pc !== undefined) {
+			names.push("<a href=\"event:pc|" + pc.tsid + "\">" + utils.escape(pc.label) + "</a>");
+		}
 	}
 	
 	var msg = "You are the only person here.";


### PR DESCRIPTION
This allows players to interact with eachother without having to talk in a group first.

There is a slight bug with player name colours occasionally not appearing but that is a client-side issue.

Fixes https://trello.com/c/9oPlsM03