### PR TITLE
Fix visiting stones

### DIFF
--- a/config_prod.js
+++ b/config_prod.js
@@ -1327,6 +1327,7 @@ var paradise_locations = {
 var recipe_xp_caps = true;
 
 var portal_group = 'RIFQS6N3PLH2TL4';
+var visiting_group = 'RVSDF6A3CYU2GY4';
 
 var teleportation_ok_streets = ['LDOOSA8V29J24I3', 'LA9QUBPI49J2MOB', 'LUV1CSSE49J2P2C']; // Streets where teleportation targets/scripts are ok, even if locked, etc
 var machine_rooms = ['LCR101Q98A12EHH', 'LIF16EM56A12FSB', 'LA9MU59GB792T80'];

--- a/groups/visiting.js
+++ b/groups/visiting.js
@@ -1,0 +1,25 @@
+// init group.
+function init() {
+    if (!this.locations) {
+        this.locations = [];
+    }
+}
+
+// fetch random player from opt-in list.
+function fetch() {
+    this.init();
+    return this.locations[Math.floor(Math.random() * this.locations.length)];
+}
+
+// opt-in to house visiting.
+function opt_in(pc) {
+    this.init();
+    this.locations.push(pc.tsid);
+    return {ok: 1};
+};
+
+// opt-out of house visiting.
+function opt_out(pc) {
+    delete this.locations[this.locations.indexOf(pc.tsid)];
+    return {ok: 1};
+};

--- a/players/inc_visiting.js
+++ b/players/inc_visiting.js
@@ -1,129 +1,95 @@
-function visiting_can_opt_in(){
-
+function visiting_can_opt_in() {
+	// Player must be level 5 or over...
 	if (this.stats.level < 4){
-		return {
-			ok: 0,
-			error: 'low_level',
-		};
+		return {ok: 0, error: 'low_level'};
 	}
 
+	// Player must have a home...
 	if (!this.home || !this.home.exterior){
-		return {
-			ok: 0,
-			error: 'no_home',
-		};
+		return {ok: 0, error: 'no_home'};
 	}
 
+	// Player must have 3 cultivations...
 	var jobs = this.home.exterior.cultivation_count_all_items();
-
 	if (jobs < 3){
-		return {
-			ok: 0,
-			error: 'no_cultivation',
-			jobs: jobs,
-		};
+		return {ok: 0, error: 'no_cultivation', jobs: jobs};
 	}
 
+	// Player must have a butler...
 	if (!this.has_butler()){
-		return {
-			ok: 0,
-			error: 'no_butler',
-		};
+		return {ok: 0, error: 'no_butler'};
 	}
 
-	return {
-		ok: 1,
-	};
+	// All good!
+	return {ok: 1};
 }
 
-function visiting_opt_in_done(){
-	this.home_allow_visits = true;
-	this.sendActivity("You've been opted in - you will recieve random visitors to your street.");
-}
-
-function visiting_opt_out_done(){
-	delete this.home_allow_visits;
-	this.sendActivity("You've been opted out - you will no longer receive random visitors to your street.");
-}
-
-function visiting_opt_in(){
-
+function visiting_opt_in() {
+	// Check if we already have opted in.
 	if (this.home_allow_visits){
-		return {
-			ok: 1,
-		};
+		return {ok: 1};
 	}
 
+	// Check if we can opt in.
 	var ret = this.visiting_can_opt_in();
-	if (!ret.ok) return ret;
+	if (!ret.ok) {
+		return ret;
+	}
 
-	utils.http_post('callbacks/player_random_visits.php', {
-		'player' : this.tsid,
-		'opt_in' : 1,
-	});
-
-	return {
-		ok: 1,
-		async: 1,
-	};
+	// All clear, lets opt-in!
+	var visiting_group = api.apiFindObject(config.visiting_group);
+	if (!visiting_group) {
+		return this.sendActivity("Uh-oh! I can't seem to find the street list. Please try again later.");
+	}
+	var rsp = visiting_group.opt_in(this);
+	if (rsp.ok) {
+		this.home_allow_visits = true;
+		this.sendActivity("You've been opted in - you will recieve random visitors to your street.");
+	}
+	else {
+		this.sendActivity("Something seems to have gone wrong. Please try again later!");
+	}
+	return {ok: 1};
 }
 
-function visiting_opt_out(){
-
+function visiting_opt_out() {
+	// Check if we already have opted out.
 	if (!this.home_allow_visits){
-		return {
-			ok: 1,
-		};
+		return {ok: 1};
 	}
 
-	utils.http_post('callbacks/player_random_visits.php', {
-		'player' : this.tsid,
-	});
-
-	return {
-		ok: 1,
-		async: 1,
-	};
+	// All clear, lets opt-out!
+	var visiting_group = api.apiFindObject(config.visiting_group);
+	if (!visiting_group) {
+		return this.sendActivity("Uh-oh! I can't seem to find the street list. Please try again later.");
+	}
+	var rsp = visiting_group.opt_out(this);
+	if (rsp.ok) {
+		delete this.home_allow_visits;
+		this.sendActivity("You've been opted out - you will no longer receive random visitors to your street.");
+	}
+	else {
+		this.sendActivity("Something seems to have gone wrong. Please try again later!");
+	}
+	return {ok: 1};
 }
 
-function visiting_visit_random(){
-
-	utils.http_post('callbacks/player_random_go.php', {
-		'player' : this.tsid,
-	});
-}
-
-function visiting_visit_random_go(){
-
-	var tsids = [];
-	for (var i=0; i < arguments.length; i++){
-		tsids.push(arguments[i]);
+function visiting_visit_random() {
+	var visiting_group = api.apiFindObject(config.visiting_group);
+	if (!visiting_group) {
+		return this.sendActivity("Uh-oh! I can't seem to find the street list. Please try again later.");
 	}
 
-	if (config.is_dev){
-		this.sendActivity("(DEBUG) Targets: "+tsids.join(','));
+	var target = visiting_group.fetch();
+	if (!target) {
+		return this.sendActivity("I couldn't find a street to send you to. Sorry about that!");
 	}
 
-	var errors = [];
-
-	for (var i=0; i < tsids.length; i++){
-
-		if (tsids[i] == this.tsid){
-
-			errors.push('self');
-		}else{
-			var ret = this.houses_visit(tsids[i]);
-			if (ret.ok){
-				this.achievements_increment('visit_random', tsids[i], 1);
-				return;
-			}
-			errors.push(ret.error);
-		}
+	var ret = this.houses_visit(target);
+	if (ret.ok) {
+		this.achievements_increment('visit_random', target, 1);
 	}
-
-	if (config.is_dev){
-		this.sendActivity("(DEBUG) Failed all targets: "+errors.join(', '));
+	else {
+		this.sendActivity("We ran in to a problem teleporting you to a street. Please try again!");
 	}
-
-	this.sendActivity("Hmm, something went wrong :(");
 }


### PR DESCRIPTION
* Instead of making webapp callbacks, a new group is used to store all
player TSIDs that have opted in. This is basic right now and doesn't
check if the target is the current player or send multiple locations if
the first location recieved is invalid.
* Cleaned up inc_visiting removing redundant functions that were used by
the webapp.

Requires a new group object RVSDF6A3CYU2GY4 in eleven-fixtures to work.

Fixes https://trello.com/c/0Gwh0JFc