### PR TITLE
Remove metalizeComplete call in npc_sloth onLoad

### DIFF
--- a/items/npc_sloth.js
+++ b/items/npc_sloth.js
@@ -583,8 +583,6 @@ function onIdleTick(){ // defined by npc_sloth
 
 function onLoad(){ // defined by npc_sloth
 	this.onPrototypeChanged();
-
-	this.metalizeComplete();
 }
 
 function onPlayerCollision(pc){ // defined by npc_sloth


### PR DESCRIPTION
* metalizeComplete sets last_metalize_time to the current time, which
results in a sloth becoming full as its loaded.

Fixes https://trello.com/c/7usWvOS4