### PR TITLE
Add parent information to split itemstacks

### DIFF
--- a/main.js
+++ b/main.js
@@ -3245,6 +3245,7 @@ function doVerb(pc, msg) {
 	if (temp){
 		old_it = it;
 		it = temp;
+		temp.parent_tsid = old_it.tsid;
 	}
 	var old_count = it.count;
 


### PR DESCRIPTION
* When we drop part of an itemstack, a new itemstack is created which is
then put in to the location. As this new itemstack does not contain any
reference to its parent we cannot create a complete itemstack animation
announcement for it. With this change, `parent_tsid` is set to the
parent so we can complete the announcement.