### PR TITLE
Minor fix to adminGetProfile

### DIFF
--- a/players/inc_admin.js
+++ b/players/inc_admin.js
@@ -248,7 +248,7 @@ function adminGetProfile(args){
 	var latest_skill = this.skillsGetLatest();
 	out.latest_skill = {};
 
-	if (typeof(latest_skill) != 'undefined'){
+	if (latest_skill.id) {
 		var latest_skill_data = this.skills_get(latest_skill.id);
 		out.latest_skill = {
 			'id' : latest_skill.id,


### PR DESCRIPTION
* `skillsGetLatest` always returns an object, so the typeof statement
always returns true. We should instead check to see if `latest_skill.id`
is set before adding latest skill info to the output.