### PR TITLE
Adjust co-ords of flying box passed to apiStartFlyingInTheAreaX()

### DIFF
--- a/items/npc_firefly.js
+++ b/items/npc_firefly.js
@@ -354,7 +354,7 @@ function onCreateAsCopy(){ // defined by npc_firefly
 function startFlying(box_center){ // defined by npc_firefly
 	var box_width = intval(this.getInstanceProp('box_width'));
 	var box_height = intval(this.getInstanceProp('box_height'));
-	this.apiStartFlyingInTheAreaX(box_center[0], box_center[1], box_width, box_height, 15, false);
+	this.apiStartFlyingInTheAreaX(box_center[0]-box_width/2, box_center[1]-box_height/2, box_width, box_height, 15, false);
 }
 
 function wandering_onEnter(previous_state){ // defined by npc_firefly


### PR DESCRIPTION
The function apiStartFlyingInTheAreaX() expects co-ordinates of the top
LH corner of the flying box to be passed as parameters. Currently the
co-ordinates of the centre of the flying box are being passed instead.
Consequently, if the firefly spawner is set up with the default 100px
radius, then the flying box which is hardcoded to 200px wide x 50px high,
ends up extending beyond the spawner on the RHS by 100px. This results in fireflies
being spawned, flying in this box beyond the spawner range, and so not
being registered by the spawner when it comes to check if the max_count
has been exceeded. Hence the spawner keeps spawning fireflies beyond
max_count.

With this fix, the flying box is centred on the spawner and so is
contained within a firefly spawner which is configured with a radius of
100px or more (as the fireflies do wander a bit beyond the flying box, a
radius of 120px is advised to make sure the count is more accurate).

An alternative solution was to instead change apiStartFlyingInTheAreaX()
to convert the co-ordinates from box-centre to LH corner. However whilst
this would have fixed the firefly case, it caused problems with the yoga
frog which also calls this function. Currently the yoga frog correctly
visits the player equidistantly from LHS or RHS. However, with this
suggested fix, the yoga frog path was shifted to the LHS - so it arrived
too close to the player if approaching from the RHS, and if coming from
the LHS was too far out to ever stop circling before dropping down to
face level. Consequently this proposed alternative solution was
abandoned.