### PR TITLE
Call geo update func on tower nudge

### DIFF
--- a/locations/inc_homes.js
+++ b/locations/inc_homes.js
@@ -3104,6 +3104,9 @@ function homes_position_tower(tower, x, y){
 		'y'		: teleport_pos[1],
 	};
 
+	// tell GS that the geometry has changed. unclear why 
+	// this was not required with the original server
+	this.apiGeometryUpdated();
 
 	//
 	// finally, make sure the tower exits here

--- a/locations/tower.js
+++ b/locations/tower.js
@@ -1181,6 +1181,10 @@ function tower_build_exit(){
 			h		: geo_cfg.door_deco_h,
 		},
 	};
+
+	// tell GS that the geometry has changed. unclear why 
+	// this was not required with the original server
+	this.apiGeometryUpdated();
 }
 
 function tower_set_label(label){


### PR DESCRIPTION
* The GSJS updates the `target` with new info even on nudges. This means that `street_tsid` and `label` are removed and not added back. Calling `apiGeometryUpdated` fixes this.

fixes https://trello.com/c/mSVIPvjU