### PR TITLE
Delete wheels without owners onload

### DIFF
--- a/items/npc_spinning_wheel.js
+++ b/items/npc_spinning_wheel.js
@@ -470,6 +470,11 @@ function setMovementLimits(x_pos, y_pos, width){ // defined by npc
 	//log.info("move_limits is "+this.move_limits);
 }
 
+function onload() {
+	// if we persisted this without an owner, remove it.
+	if (!this.owner) this.apiDelete();
+}
+
 function getDescExtras(pc){
 	var out = [];
 	return out;


### PR DESCRIPTION
* Spinning wheels can occasionally get stuck due to losing owner info (possibly on disconnect or server shutdown). If we load a wheel without owner info, just delete it.

fixes https://trello.com/c/XJQdUiIe