### PR TITLE
Safely handle cases where messages are null

### DIFF
--- a/items/include/butler_data.js
+++ b/items/include/butler_data.js
@@ -734,7 +734,7 @@ function getNumPackagesWithMessages() {
 	
 	for (var tsid in messages) { 
 		for (var i in messages[tsid]) {
-			if (messages[tsid][i].withPackage) {
+			if (messages[tsid][i] && messages[tsid][i].withPackage) {
 				count ++;
 			}
 		}


### PR DESCRIPTION
* For reasons unknown, a butlers message DC may contain `null` entries in its `list` for a player (an empty message). These should ideally be removed, but in cases where they aren't, gracefully ignore them instead of kicking the player out when checking for packages.